### PR TITLE
Update deploy token variable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - run: deno task check
+      - uses: denoland/deployctl@v1
+        with:
+          project: cosense-exporter
+          entrypoint: server.ts
+          token: ${{ secrets.DENO_DEPLOY_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -18,3 +18,19 @@ deno task start
    - `/api/export` は ZIP ファイルを返します。
 
 ※ 現時点では実データ取得は行わず、スタブレスポンスのみ返します。
+
+## 開発
+
+コードの整形と Lint をまとめて実行する `deno task check` を用意しています。
+開発時は次のコマンドでチェックできます。
+
+```bash
+deno task check
+```
+
+## デプロイ
+
+本リポジトリには Deno Deploy へ自動デプロイする GitHub Actions ワークフロー
+`deploy.yml` が含まれています。あらかじめ Deno Deploy
+でプロジェクトを作成し、GitHub リポジトリをリンクして取得したトークンを GitHub
+の Secrets に `DENO_DEPLOY_ACCESS_TOKEN` として登録してください。

--- a/deno.json
+++ b/deno.json
@@ -2,6 +2,7 @@
   "tasks": {
     "start": "deno run --allow-net server.ts",
     "fmt": "deno fmt",
-    "lint": "deno lint"
+    "lint": "deno lint",
+    "check": "deno lint && deno fmt --check"
   }
 }


### PR DESCRIPTION
## Summary
- デプロイワークフローで参照するシークレット名を `DENO_DEPLOY_ACCESS_TOKEN` に変更
- README の説明を同様に修正

## Testing
- `deno fmt README.md deno.json .github/workflows/deploy.yml`
- `deno fmt --check README.md deno.json .github/workflows/deploy.yml`
- `deno lint`
- `deno install -g -A -f -n deployctl https://deno.land/x/deploy/deployctl.ts` *(失敗)*

------
https://chatgpt.com/codex/tasks/task_e_6857d8ba3adc833184fc53a79e47af43