### PR TITLE
Add manual deploy task

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - run: deno task check
+      - uses: denoland/deployctl@v1
+        with:
+          project: cosense-exporter
+          entrypoint: server.ts
+          token: ${{ secrets.DENO_DEPLOY_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -18,3 +18,25 @@ deno task start
    - `/api/export` は ZIP ファイルを返します。
 
 ※ 現時点では実データ取得は行わず、スタブレスポンスのみ返します。
+
+## 開発
+
+コードの整形と Lint をまとめて実行する `deno task check` を用意しています。
+開発時は次のコマンドでチェックできます。
+
+```bash
+deno task check
+```
+
+## デプロイ
+
+本リポジトリには Deno Deploy へ自動デプロイする GitHub Actions ワークフロー
+`deploy.yml` が含まれています。あらかじめ Deno Deploy
+でプロジェクトを作成し、GitHub リポジトリをリンクして取得したトークンを GitHub
+の Secrets に `DENO_DEPLOY_ACCESS_TOKEN` として登録してください。
+
+手動デプロイ用に `deno task deploy` も用意しました。事前に `deployctl`
+をインストールし、環境変数 `DENO_DEPLOY_ACCESS_TOKEN`
+を設定して実行してください。 また、GitHub Actions のワークフローは
+`workflow_dispatch` にも対応しているため、 リポジトリの Actions
+タブから手動で実行することも可能です。

--- a/deno.json
+++ b/deno.json
@@ -2,6 +2,8 @@
   "tasks": {
     "start": "deno run --allow-net server.ts",
     "fmt": "deno fmt",
-    "lint": "deno lint"
+    "lint": "deno lint",
+    "check": "deno lint && deno fmt --check",
+    "deploy": "deployctl deploy --project=cosense-exporter server.ts"
   }
 }


### PR DESCRIPTION
## Summary
- `deno task deploy` を追加し、ローカルからのデプロイを可能に
- README に手動デプロイ方法と GitHub Actions の手動実行方法を追記

## Testing
- `deno fmt README.md deno.json .github/workflows/deploy.yml`
- `deno fmt --check README.md deno.json .github/workflows/deploy.yml`
- `deno lint`
- `deno install -g -A -f -n deployctl https://deno.land/x/deploy/deployctl.ts` *(失敗: 証明書エラー)*

------
https://chatgpt.com/codex/tasks/task_e_6857d8ba3adc833184fc53a79e47af43