### PR TITLE
Fix lockfile error by using Deno v2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.x
+          deno-version: v2.x
       - run: deno task check
       - uses: denoland/deployctl@v1
         with:


### PR DESCRIPTION
## Summary
- GitHub Actions で `deno task check` が失敗していたのは、lockfile のバージョン5を Deno 1.x が理解できなかったため
- ワークフローで Deno 2.x を使うよう更新

## Testing
- `deno task check`

------
https://chatgpt.com/codex/tasks/task_e_6857facc63348331a53f967ba46adc07