### PR TITLE
Fix YAML formatting for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read     # ソースコードチェックアウト用
-  id-token: write    # ← OIDC トークン発行を許可
+  contents: read # ソースコードチェックアウト用
+  id-token: write # ← OIDC トークン発行を許可
 
 jobs:
   deploy:


### PR DESCRIPTION
## 概要
`deno task check` が失敗していた `.github/workflows/deploy.yml` の整形を修正しました。

## 変更内容
- `permissions` セクションのコメント前の余分な空白を削除

## テスト
- `deno task check` を実行し、エラーがないことを確認


------
https://chatgpt.com/codex/tasks/task_e_6857fc78511083319886088052604e65