### PR TITLE
Add stub modules and update server

### DIFF
--- a/cosense.ts
+++ b/cosense.ts
@@ -1,0 +1,21 @@
+export interface Page {
+  path: string;
+  content: string;
+  binary?: Uint8Array;
+}
+
+/**
+ * Cosense APIからページと画像を取得するスタブ実装。
+ * 実際のAPI連携は未実装で、固定データを返す。
+ */
+export function fetchPages(
+  project: string,
+  _sid?: string,
+): Promise<Page[]> {
+  const text = `# ${project}\nサンプルページ`;
+  return Promise.resolve([
+    { path: "README.md", content: text },
+    { path: "docs/spec.md", content: "# 仕様\n" },
+    { path: "images/logo.png", content: "", binary: new Uint8Array() },
+  ]);
+}

--- a/file_tree.ts
+++ b/file_tree.ts
@@ -1,0 +1,36 @@
+import type { Page } from "./cosense.ts";
+
+export interface FileNode {
+  path: string;
+  type: "file" | "dir";
+  size?: number;
+}
+
+/**
+ * ページ配列からファイルツリー情報を生成する単純な実装。
+ */
+export function buildFileTree(pages: Page[]): FileNode[] {
+  const dirs = new Set<string>();
+  const nodes: FileNode[] = [];
+
+  for (const page of pages) {
+    const size = page.binary
+      ? page.binary.length
+      : new TextEncoder().encode(page.content).length;
+    nodes.push({ path: page.path, type: "file", size });
+
+    const parts = page.path.split("/");
+    parts.pop();
+    let prefix = "";
+    for (const part of parts) {
+      prefix += part + "/";
+      if (!dirs.has(prefix)) {
+        dirs.add(prefix);
+        nodes.push({ path: prefix, type: "dir" });
+      }
+    }
+  }
+
+  nodes.sort((a, b) => a.path.localeCompare(b.path));
+  return nodes;
+}

--- a/zip.ts
+++ b/zip.ts
@@ -1,0 +1,17 @@
+import { JSZip } from "https://deno.land/x/jszip@0.11.0/mod.ts";
+import type { Page } from "./cosense.ts";
+
+/**
+ * ページ配列から ZIP バイト列を生成するヘルパー。
+ */
+export async function buildZip(pages: Page[]): Promise<Uint8Array> {
+  const zip = new JSZip();
+  for (const page of pages) {
+    if (page.binary) {
+      zip.addFile(page.path, page.binary);
+    } else {
+      zip.addFile(page.path, page.content);
+    }
+  }
+  return await zip.generateAsync({ type: "uint8array" });
+}


### PR DESCRIPTION
## 変更内容
- Cosense API 取得用のスタブ `cosense.ts` を追加
- ファイルツリー生成 `file_tree.ts` を追加
- ZIP 作成ヘルパー `zip.ts` を追加
- 既存の `server.ts` を上記モジュール利用に書き換え

## テスト
- `deno task check` を実行し lint/format チェックを確認

------
https://chatgpt.com/codex/tasks/task_e_685800ff76c08331af6a90d15cd7d3d7