### PR TITLE
Fix deploy project name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,5 +21,6 @@ jobs:
       - run: deno task check
       - uses: denoland/deployctl@v1
         with:
-          project: cosense-exporter
+          project: namnam-cosense-exp-47
           entrypoint: server.ts
+          token: ${{ secrets.DENO_DEPLOY_ACCESS_TOKEN }}

--- a/deno.json
+++ b/deno.json
@@ -4,6 +4,6 @@
     "fmt": "deno fmt",
     "lint": "deno lint",
     "check": "deno lint --ignore=docs && deno fmt --check --ignore=docs",
-    "deploy": "deployctl deploy --project=cosense-exporter server.ts"
+    "deploy": "deployctl deploy --project=namnam-cosense-exp-47 server.ts"
   }
 }


### PR DESCRIPTION
## 概要
Deno Deploy の正式なプロジェクト名は `namnam-cosense-exp-47` であるため、
GitHub Actions と `deno.json` の手動デプロイ設定を修正しました。

## テスト内容
- `deno task check` が成功することを確認しました。

------
https://chatgpt.com/codex/tasks/task_e_6858130bc76c83318a3a7ccc224962b4