### PR TITLE
Fix server start permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 
 ```bash
 deno task start
+(内部で `--allow-net` と `--allow-env` を付与しています)
 ```
 
 3. `POST /api/preview` または `POST /api/export` に JSON `{ project: "<id>" }`

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "start": "deno run --allow-net server.ts",
+    "start": "deno run --allow-net --allow-env server.ts",
     "fmt": "deno fmt",
     "lint": "deno lint",
     "check": "deno lint --ignore=docs && deno fmt --check --ignore=docs",


### PR DESCRIPTION
## 概要
start タスク実行時に `JSZip` が環境変数アクセスを要求してサーバー起動に失敗する問題を修正しました。`deno.json` の start タスクに `--allow-env` を追加し、README にも説明を追記しています。

## テスト
- `deno task check` を実行し、lint と fmt が成功することを確認しました。

------
https://chatgpt.com/codex/tasks/task_e_6858171e6a6c8331a9a71cf2e643ff8d