### PR TITLE
Add simple web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ deno task start
 (内部で `--allow-net` と `--allow-env` を付与しています)
 ```
 
-3. `POST /api/preview` または `POST /api/export` に JSON `{ project: "<id>" }`
-   を送信します。
+3. ブラウザで `http://localhost:8000/` にアクセスすると、プロジェクト ID と sid
+   を入力するフォームが表示されます。プレビューボタンで `/api/preview` を、
+   エクスポートボタンで `/api/export` を呼び出します。
    - `/api/preview` はファイルツリーとサンプル HTML を JSON で返します。
    - `/api/export` は ZIP ファイルを返します。
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Cosense Exporter</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/tailwindcss@3.3.5/dist/tailwind.min.css"
+      rel="stylesheet"
+    >
+  </head>
+  <body class="bg-gray-100">
+    <header class="bg-emerald-500 text-white p-4">
+      <h1 class="text-xl">Cosense Exporter</h1>
+    </header>
+    <main class="max-w-lg mx-auto mt-10 bg-white rounded-2xl shadow-md p-6">
+      <label class="block">
+        プロジェクトID / URL
+        <input id="project" class="w-full border p-2 rounded mt-1" />
+      </label>
+      <label class="block mt-4">
+        sid Cookie (任意)
+        <input id="sid" class="w-full border p-2 rounded mt-1" />
+      </label>
+      <div class="mt-6 flex justify-between">
+        <button
+          id="previewBtn"
+          class="px-4 py-2 bg-blue-500 text-white rounded"
+        >
+          プレビュー
+        </button>
+        <button
+          id="exportBtn"
+          class="px-4 py-2 bg-emerald-500 text-white rounded"
+        >
+          エクスポート
+        </button>
+      </div>
+      <pre id="result" class="mt-6 whitespace-pre-wrap"></pre>
+    </main>
+    <script>
+      async function doPreview() {
+        const project = document.getElementById("project").value;
+        const sid = document.getElementById("sid").value || undefined;
+        const res = await fetch("/api/preview", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ project, sid }),
+        });
+        const data = await res.json();
+        document.getElementById("result").textContent = JSON.stringify(
+          data,
+          null,
+          2,
+        );
+      }
+
+      async function doExport() {
+        const project = document.getElementById("project").value;
+        const sid = document.getElementById("sid").value || undefined;
+        const res = await fetch("/api/export", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ project, sid }),
+        });
+        const blob = await res.blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "export.zip";
+        a.click();
+        URL.revokeObjectURL(url);
+      }
+
+      document.getElementById("previewBtn").addEventListener(
+        "click",
+        doPreview,
+      );
+      document.getElementById("exportBtn").addEventListener(
+        "click",
+        doExport,
+      );
+    </script>
+  </body>
+</html>

--- a/server.ts
+++ b/server.ts
@@ -5,6 +5,14 @@ import { buildZip } from "./zip.ts";
 
 const handler = async (req: Request): Promise<Response> => {
   const { pathname } = new URL(req.url);
+  if (
+    req.method === "GET" && (pathname === "/" || pathname === "/index.html")
+  ) {
+    const html = await Deno.readTextFile("./index.html");
+    return new Response(html, {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  }
   if (req.method === "POST" && pathname === "/api/preview") {
     const { project, sid } = await req.json();
     const pages = await fetchPages(project, sid);


### PR DESCRIPTION
## 概要
Wireframe に沿って簡易的なフォームページを実装しました。これによりブラウザからプロジェクト ID と sid を入力し、プレビューやエクスポートを試せます。

## 変更点
- `index.html` を追加し、Tailwind CDN を用いてフォームを整備
- `server.ts` に `/` への GET ルートを追加し `index.html` を返却
- README の使い方をブラウザアクセスの説明に更新

## テスト
- `deno task check` を実行し lint/format が通ることを確認

------
https://chatgpt.com/codex/tasks/task_e_6858191bb628833187bc6c33451372a4