### PR TITLE
Show file tree in preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,9 +36,36 @@
           エクスポート
         </button>
       </div>
-      <pre id="result" class="mt-6 whitespace-pre-wrap"></pre>
+      <div id="previewContainer" class="mt-6">
+        <pre id="tree" class="whitespace-pre-wrap"></pre>
+        <div id="sample" class="mt-4"></div>
+      </div>
     </main>
     <script>
+      function formatTree(nodes) {
+        nodes.sort((a, b) => a.path.localeCompare(b.path));
+        const lines = [];
+        const seen = new Set();
+        for (const node of nodes) {
+          const parts = node.path.split("/").filter((p) => p);
+          let partial = "";
+          for (let i = 0; i < parts.length; i++) {
+            const part = parts[i];
+            const isDir = i < parts.length - 1 || node.type === "dir";
+            if (isDir) {
+              partial += part + "/";
+              if (!seen.has(partial)) {
+                lines.push("  ".repeat(i) + part + "/");
+                seen.add(partial);
+              }
+            } else {
+              lines.push("  ".repeat(i) + part);
+            }
+          }
+        }
+        return lines.join("\n");
+      }
+
       async function doPreview() {
         const project = document.getElementById("project").value;
         const sid = document.getElementById("sid").value || undefined;
@@ -48,11 +75,10 @@
           body: JSON.stringify({ project, sid }),
         });
         const data = await res.json();
-        document.getElementById("result").textContent = JSON.stringify(
-          data,
-          null,
-          2,
+        document.getElementById("tree").textContent = formatTree(
+          data.fileTree,
         );
+        document.getElementById("sample").innerHTML = data.sampleHtml;
       }
 
       async function doExport() {


### PR DESCRIPTION
## 概要
プレビュー時に JSON がそのまま表示されていたため、ファイル構造が分かりやすいようツリー表示を追加しました。サンプル HTML も同時に表示されます。

## 変更点
- プレビュー結果用の要素を追加し、`formatTree` 関数でファイルツリーを整形
- `/api/preview` のレスポンスをツリー表示と Markdown プレビューへ反映

## テスト
- `deno task check` を実行し、Lint とフォーマットチェックが通ることを確認しました。


------
https://chatgpt.com/codex/tasks/task_e_68581e2dafec833190e5a844972aa029