### PR TITLE
Vercel エッジ対応

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read # allow GitHub to read repository contents
-  id-token: write # required for authentication with Deno Deploy
+  contents: read
 
 jobs:
   deploy:
@@ -19,7 +18,11 @@ jobs:
         with:
           deno-version: v2.x
       - run: deno task check
-      - uses: denoland/deployctl@v1
+      - uses: amondnet/vercel-action@v25
         with:
-          project: namnam-cosense-exp-47
-          entrypoint: server.ts
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: .
+          vercel-args: "--prod"
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -63,18 +63,14 @@ deno task start
 deno task check
 ```
 
-## デプロイ
+## デプロイ (Vercel)
 
-本リポジトリには Deno Deploy へ自動デプロイする GitHub Actions ワークフロー
-`deploy.yml` が含まれています。あらかじめ Deno Deploy
-でプロジェクトを作成し、GitHub リポジトリをリンクして取得したトークンを GitHub
-の Secrets に `DENO_DEPLOY_ACCESS_TOKEN` として登録してください。
+Vercel へ自動デプロイする GitHub Actions ワークフロー `deploy.yml`
+を用意しています。 あらかじめ Vercel でプロジェクトを作成し、Secrets に
+`VERCEL_TOKEN`、 `VERCEL_ORG_ID`、`VERCEL_PROJECT_ID` を登録してください。
 
-手動デプロイ用に `deno task deploy` も用意しました。事前に `deployctl`
-をインストールし、環境変数 `DENO_DEPLOY_ACCESS_TOKEN`
-を設定して実行してください。 また、GitHub Actions のワークフローは
-`workflow_dispatch` にも対応しているため、 リポジトリの Actions
-タブから手動で実行することも可能です。
+push すると Preview URL が発行され、`--prod` オプションを指定すると本番環境へ
+デプロイできます。
 
 ## KV 履歴レコードスキーマ
 

--- a/api/export.ts
+++ b/api/export.ts
@@ -1,0 +1,19 @@
+import { fetchPages } from "../cosense.ts";
+import { buildZip } from "../zip.ts";
+
+export const config = { runtime: "vercel-deno@3.1.1" };
+
+export default async function handler(req: Request): Promise<Response> {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  const { project, sid } = await req.json();
+  const pages = await fetchPages(project, sid);
+  const data = await buildZip(pages);
+  return new Response(data, {
+    headers: {
+      "Content-Type": "application/zip",
+      "Content-Disposition": "attachment; filename=export.zip",
+    },
+  });
+}

--- a/api/preview.ts
+++ b/api/preview.ts
@@ -1,0 +1,16 @@
+import { fetchPages } from "../cosense.ts";
+import { buildFileTree, FileNode } from "../file_tree.ts";
+
+export const config = { runtime: "vercel-deno@3.1.1" };
+
+export default async function handler(req: Request): Promise<Response> {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  const { project, sid } = await req.json();
+  const pages = await fetchPages(project, sid);
+  const fileTree: FileNode[] = buildFileTree(pages);
+  const readme = pages.find((p) => p.path === "README.md");
+  const sampleHtml = `<pre>${readme?.content ?? ""}</pre>`;
+  return Response.json({ fileTree, sampleHtml });
+}

--- a/deno.json
+++ b/deno.json
@@ -4,6 +4,6 @@
     "fmt": "deno fmt",
     "lint": "deno lint",
     "check": "deno lint --ignore=docs && deno fmt --check --ignore=docs",
-    "deploy": "deployctl deploy --project=namnam-cosense-exp-47 server.ts"
+    "deploy": "vercel deploy --prod"
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "functions": {
+    "api/**/*.ts": {
+      "runtime": "vercel-deno@3.1.1"
+    }
+  },
+  "routes": [
+    { "src": "/api/(.*)", "dest": "/api/$1.ts" },
+    { "src": "/(.*)", "dest": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## 変更点
- Edge Functions 用の `api/preview.ts`, `api/export.ts` を追加
- `vercel.json` で Deno ランタイムを指定
- デプロイワークフローを Vercel 用に更新
- `deno.json` の deploy タスクを更新
- README のデプロイ手順を Vercel 向けに修正

## 管理者向けメモ
Vercel のプロジェクトを作成し、`VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` を GitHub Secrets に設定してください。

------
https://chatgpt.com/codex/tasks/task_e_68594168717c83318768b9e3032cab75