### PR TITLE
TODOを並列開発向けに整理

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,31 +1,31 @@
-# Cosense Export TODO（階層番号付き）
+# Cosense Export TODO（並列開発用）
 
-## 0. インターフェース確定
-- [x] **0.1** `/api/preview` のレスポンス仕様を README に記載
-- [x] **0.2** KV 履歴レコードスキーマを README に記載
+## 0. 仕様確定（ブロッキング）
+- [x] `/api/preview` のレスポンス仕様を README に記載
+- [ ] ~~KV 履歴レコードスキーマを README に記載~~ ※履歴機能撤廃
 
-## 1. 基盤移行（Fresh + React）
-- [ ] ~~**1.1** Fresh 1.8 プロジェクトへ移行（`routes/api/*.ts` へ統合）~~
-- [ ] **1.2** Deno KV 初期化コードを追加
-- [ ] **1.3** React + Vite + Tailwind を scaffold（`frontend/`）
-- [ ] **1.4** 既存 HTML UI → `ExportForm.tsx` へ置き換え
-- [ ] **1.5** GitHub Actions にフロントビルド＆`static/` 配置を追加
+## 1. 基盤セットアップ （Team A）
+- [ ] Next.js (App Router) プロジェクト作成
+- [ ] TailwindCSS + Framer Motion 導入
+- [ ] GitHub Actions で `next build`・lint 実行
 
-## 2. データ取得 & プレビュー機能
-- [ ] **2.1** `cosense.ts`：Cosense API アダプター実装
-- [ ] **2.2** `markdown.ts`：Scrapbox → Markdown 変換 + リンク書換
-- [ ] **2.3** `zip.ts`：実データ取得 + JSZip ストリーム生成
-- [ ] **2.4** `<PreviewModal>`：ツリービュー & Markdown プレビュー
-- [ ] **2.5** `<ErrorToast>`：エラーコード別トースト表示
+## 2. Edge Functions （Team B）
+- [ ] `/api/preview` ハンドラー実装
+- [ ] `/api/export` ハンドラー実装
+- [ ] `cosense.ts`: Cosense API アダプター
+- [ ] `markdown.ts`: Markdown 変換 + リンク書換
+- [ ] `zip.ts`: JSZip ストリーム生成
 
-## 3. 履歴管理 & 設定 UI
-- [ ] **3.1** `history.ts`：KV で履歴保存 / 取得 / 削除
-- [ ] **3.2** `<HistoryPage>`：履歴一覧 & プレビュー／再試行
-- [ ] **3.3** `<SettingsModal>`：設定モーダル UI
+## 3. フロントエンド （Team C）
+- [ ] `ExportForm` コンポーネント化（既存 HTML 移行）
+- [ ] `<PreviewModal>`：ツリービュー & Markdown プレビュー
+- [ ] `<SettingsModal>`：ローカル設定モーダル
+- [ ] `<ErrorToast>`：エラーコード別トースト表示
 
-## 4. テスト & 仕上げ
-- [ ] **4.1** Playwright E2E テスト（トップ → プレビュー → ダウンロード）
-- [ ] **4.2** アクセシビリティ対応（aria-label, focus trap など）
-- [ ] **4.3** ログ出力を `std/log` に統一
-- [ ] **4.4** CI に `deno task check`・ESLint・Playwright を組み込み
-- [ ] **4.5** README を最新仕様に更新
+## 4. 統合 & テスト（並列可）
+- [ ] Edge Functions と UI の連携
+- [ ] Playwright E2E テスト
+- [ ] アクセシビリティ対応（aria-label, focus trap など）
+- [ ] ログ出力を `std/log` に統一
+- [ ] CI に `next build`・ESLint・Playwright を組み込み
+- [ ] README を最新仕様に更新


### PR DESCRIPTION
## Summary
- 仕様書と要件定義を見直し、タスクを Team ごとに再編成
- 並列実装可能な構成に更新

## Testing
- `deno task check`


------
https://chatgpt.com/codex/tasks/task_e_68594b575574833185c5d0ed39f39d4c