### PR TITLE
BチームTODO実装: markdown.ts追加

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,5 +1,80 @@
 {
-  "version": "3",
+  "version": "5",
+  "specifiers": {
+    "npm:jszip@3.7.1": "3.7.1",
+    "npm:turndown@7.1.2": "7.1.2"
+  },
+  "npm": {
+    "core-util-is@1.0.3": {
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "domino@2.1.6": {
+      "integrity": "sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ=="
+    },
+    "immediate@3.0.6": {
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
+    "inherits@2.0.4": {
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "isarray@1.0.0": {
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "jszip@3.7.1": {
+      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
+      "dependencies": [
+        "lie",
+        "pako",
+        "readable-stream",
+        "set-immediate-shim"
+      ]
+    },
+    "lie@3.3.0": {
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dependencies": [
+        "immediate"
+      ]
+    },
+    "pako@1.0.11": {
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
+    "process-nextick-args@2.0.1": {
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "readable-stream@2.3.8": {
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": [
+        "core-util-is",
+        "inherits",
+        "isarray",
+        "process-nextick-args",
+        "safe-buffer",
+        "string_decoder",
+        "util-deprecate"
+      ]
+    },
+    "safe-buffer@5.1.2": {
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "set-immediate-shim@1.0.1": {
+      "integrity": "sha512-Li5AOqrZWCVA2n5kryzEmqai6bKSIvpz5oUJHPVj6+dsbD3X1ixtsY5tEnsaNpH3pFAHmG8eIHUrtEtohrg+UQ=="
+    },
+    "string_decoder@1.1.1": {
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": [
+        "safe-buffer"
+      ]
+    },
+    "turndown@7.1.2": {
+      "integrity": "sha512-ntI9R7fcUKjqBP6QU8rBK2Ehyt8LAzt3UBT9JR9tgo6GtuKvyUzpayWmeMKJw1DPdXzktvtIT8m2mVXz+bL/Qg==",
+      "dependencies": [
+        "domino"
+      ]
+    },
+    "util-deprecate@1.0.2": {
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    }
+  },
   "redirects": {
     "https://esm.sh/@types/core-util-is@~1.0.1/index.d.ts": "https://esm.sh/@types/core-util-is@1.0.1/index.d.ts",
     "https://esm.sh/@types/immediate@~3.2.2/index.d.ts": "https://esm.sh/@types/immediate@3.2.2/index.d.ts",

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -13,7 +13,7 @@
 - [ ] `/api/preview` ハンドラー実装
 - [ ] `/api/export` ハンドラー実装
 - [ ] `cosense.ts`: Cosense API アダプター
-- [ ] `markdown.ts`: Markdown 変換 + リンク書換
+- [x] `markdown.ts`: Markdown 変換 + リンク書換
 - [ ] `zip.ts`: JSZip ストリーム生成
 
 ## 3. フロントエンド （Team C）

--- a/markdown.ts
+++ b/markdown.ts
@@ -1,0 +1,23 @@
+import TurndownService from "npm:turndown@7.1.2";
+import type { Page } from "./cosense.ts";
+
+/**
+ * HTML を Markdown へ変換する。
+ */
+export function toMarkdown(page: Page): string {
+  const service = new TurndownService();
+  return service.turndown(page.content);
+}
+
+/**
+ * Markdown 内の画像 URL を相対パスに書き換える。
+ * 例: https://example.com/path/img.png -> ./images/img.png
+ */
+export function rewriteLinks(md: string): string {
+  const regexPart = "!\\[[^\\]]*\\]\\((https?:\\/\\/[^\\s)]+\\/";
+  const regex = new RegExp(
+    `${regexPart}(\\S+\\.(?:png|jpg|jpeg|gif|svg)))\\)`,
+    "gi",
+  );
+  return md.replace(regex, (_m, _url, file) => `![${file}](./images/${file})`);
+}


### PR DESCRIPTION
## 概要
- `markdown.ts` を新規追加し、HTML から Markdown への変換処理と画像リンクの書き換え関数を実装しました
- 依存ライブラリ `turndown` を `deno.lock` に追加しました
- TODOリストの `markdown.ts` 項目を完了扱いにしました

## テスト
- `deno task check` を実行し、lint とフォーマットが通ることを確認

------
https://chatgpt.com/codex/tasks/task_e_6859515b14608331bc07b8be101a2b58