### PR TITLE
Team B: マークダウン変換機能の追加

### DIFF
--- a/api/preview.ts
+++ b/api/preview.ts
@@ -1,5 +1,6 @@
 import { fetchPages } from "../cosense.ts";
 import { buildFileTree, FileNode } from "../file_tree.ts";
+import { toHtml } from "../markdown.ts";
 
 export const config = { runtime: "vercel-deno@3.1.1" };
 
@@ -11,6 +12,6 @@ export default async function handler(req: Request): Promise<Response> {
   const pages = await fetchPages(project, sid);
   const fileTree: FileNode[] = buildFileTree(pages);
   const readme = pages.find((p) => p.path === "README.md");
-  const sampleHtml = `<pre>${readme?.content ?? ""}</pre>`;
+  const sampleHtml = readme ? toHtml(readme.content) : "";
   return Response.json({ fileTree, sampleHtml });
 }

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,28 +1,33 @@
 # Cosense Export TODO（並列開発用）
 
 ## 0. 仕様確定（ブロッキング）
+
 - [x] `/api/preview` のレスポンス仕様を README に記載
 - [ ] ~~KV 履歴レコードスキーマを README に記載~~ ※履歴機能撤廃
 
 ## 1. 基盤セットアップ （Team A）
+
 - [x] Next.js (App Router) プロジェクト作成
 - [ ] TailwindCSS + Framer Motion 導入
 - [ ] GitHub Actions で `next build`・lint 実行
 
 ## 2. Edge Functions （Team B）
+
 - [ ] `/api/preview` ハンドラー実装
 - [ ] `/api/export` ハンドラー実装
 - [ ] `cosense.ts`: Cosense API アダプター
-- [ ] `markdown.ts`: Markdown 変換 + リンク書換
+- [x] `markdown.ts`: Markdown 変換 + リンク書換
 - [ ] `zip.ts`: JSZip ストリーム生成
 
 ## 3. フロントエンド （Team C）
+
 - [ ] `ExportForm` コンポーネント化（既存 HTML 移行）
 - [ ] `<PreviewModal>`：ツリービュー & Markdown プレビュー
 - [ ] `<SettingsModal>`：ローカル設定モーダル
 - [ ] `<ErrorToast>`：エラーコード別トースト表示
 
 ## 4. 統合 & テスト（並列可）
+
 - [ ] Edge Functions と UI の連携
 - [ ] Playwright E2E テスト
 - [ ] アクセシビリティ対応（aria-label, focus trap など）

--- a/markdown.ts
+++ b/markdown.ts
@@ -1,0 +1,28 @@
+/**
+ * 非依存の簡易 Markdown → HTML 変換。
+ * 見出しと強調、一部インライン記法のみ対応する。
+ */
+export function toHtml(md: string): string {
+  return md
+    .replace(/^### (.*)$/gm, "<h3>$1</h3>")
+    .replace(/^## (.*)$/gm, "<h2>$1</h2>")
+    .replace(/^# (.*)$/gm, "<h1>$1</h1>")
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*(.+?)\*/g, "<em>$1</em>")
+    .replace(/`([^`]+)`/g, "<code>$1</code>")
+    .replace(/\n/g, "<br>");
+}
+
+/**
+ * 画像URLをローカルの images/ ディレクトリ参照に書き換える。
+ *   ![alt](https://example.com/foo.png) -> ![alt](images/foo.png)
+ */
+export function rewriteLinks(md: string): string {
+  return md.replace(
+    /!\[([^\]]*)\]\((https?:\/\/[^\s)]+)\)/g,
+    (_, alt: string, url: string) => {
+      const filename = url.substring(url.lastIndexOf("/") + 1);
+      return `![${alt}](images/${filename})`;
+    },
+  );
+}


### PR DESCRIPTION
## 変更内容
- `markdown.ts` を追加し、簡易的な Markdown→HTML 変換と画像リンク書換え処理を実装しました
- `/api/preview` で README.md を HTML 化して返すよう更新しました
- `docs/TODO.md` の Team B タスク `markdown.ts` を完了扱いにしました

## 動作確認
- `deno task check` を実行し、lint と fmt が通ることを確認しました

------
https://chatgpt.com/codex/tasks/task_e_68595679b4f88331b92eb0ac844f4994