### PR TITLE
フロントエンドのNextビルドを反映

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,23 @@
 ## 使い方
 
 1. 必要であれば `./setup.sh` を実行して Deno をインストールします。
-2. 下記コマンドでサーバーを起動します。
+2. `next-app` ディレクトリでフロントエンドをビルドします。
+
+```bash
+cd next-app
+npm install
+npm run build
+cd ..
+```
+
+3. 下記コマンドでサーバーを起動します。
 
 ```bash
 deno task start
 (内部で `--allow-net` と `--allow-env` を付与しています)
 ```
 
-3. ブラウザで `http://localhost:8000/` にアクセスすると、プロジェクト ID と sid
+4. ブラウザで `http://localhost:8000/` にアクセスすると、プロジェクト ID と sid
    を入力するフォームが表示されます。プレビューボタンで `/api/preview` を、
    エクスポートボタンで `/api/export` を呼び出します。
    - `/api/preview` はファイルツリーとサンプル HTML を JSON で返します。

--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,7 @@
     "start": "deno run --allow-net --allow-env server.ts",
     "fmt": "deno fmt",
     "lint": "deno lint",
-    "check": "deno lint --ignore=docs && deno fmt --check --ignore=docs",
+    "check": "deno lint --ignore=docs,next-app && deno fmt --check --ignore=docs,next-app",
     "deploy": "vercel deploy --prod"
   }
 }

--- a/next-app/next.config.ts
+++ b/next-app/next.config.ts
@@ -1,7 +1,8 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // 静的 HTML としてエクスポートする
+  output: "export",
 };
 
 export default nextConfig;

--- a/server.ts
+++ b/server.ts
@@ -1,17 +1,36 @@
 import { serve } from "https://deno.land/std@0.203.0/http/server.ts";
+import { contentType } from "https://deno.land/std@0.203.0/media_types/mod.ts";
 import { fetchPages } from "./cosense.ts";
 import { buildFileTree, FileNode } from "./file_tree.ts";
 import { streamZip } from "./zip.ts";
 
 const handler = async (req: Request): Promise<Response> => {
   const { pathname } = new URL(req.url);
-  if (
-    req.method === "GET" && (pathname === "/" || pathname === "/index.html")
-  ) {
-    const html = await Deno.readTextFile("./index.html");
-    return new Response(html, {
-      headers: { "Content-Type": "text/html; charset=utf-8" },
-    });
+
+  if (req.method === "GET") {
+    const outPath = pathname === "/"
+      ? "./next-app/out/index.html"
+      : `./next-app/out${pathname}`;
+    try {
+      const data = await Deno.readFile(outPath);
+      return new Response(data, {
+        headers: {
+          "Content-Type": contentType(outPath) ?? "application/octet-stream",
+        },
+      });
+    } catch {
+      try {
+        const html = await Deno.readFile("./next-app/out/index.html");
+        return new Response(html, {
+          headers: { "Content-Type": "text/html; charset=utf-8" },
+        });
+      } catch {
+        const html = await Deno.readTextFile("./index.html");
+        return new Response(html, {
+          headers: { "Content-Type": "text/html; charset=utf-8" },
+        });
+      }
+    }
   }
   if (req.method === "POST" && pathname === "/api/preview") {
     const { project, sid } = await req.json();

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,9 @@
   },
   "routes": [
     { "src": "/api/(.*)", "dest": "/api/$1.ts" },
-    { "src": "/(.*)", "dest": "/index.html" }
+    { "src": "/_next/static/(.*)", "dest": "/next-app/out/_next/static/$1" },
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/next-app/out/$1" },
+    { "src": "/(.*)", "dest": "/next-app/out/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- Next.js を `output: export` でビルドして静的ファイルとして提供
- Vercel ルーティングを `next-app/out` を参照するよう更新
- 開発サーバーで Next の静的ファイルを返すよう server.ts を更新
- フロントビルド手順を README に追記
- `deno task check` が不要ファイルを検査しないよう修正

## Testing
- `deno task check`

------
https://chatgpt.com/codex/tasks/task_e_68596df0d81c83318cb2ea3a8f38eed6