### PR TITLE
チームB TODO実装: Cosense APIアダプター

### DIFF
--- a/cosense.ts
+++ b/cosense.ts
@@ -4,18 +4,45 @@ export interface Page {
   binary?: Uint8Array;
 }
 
+const API_BASE = Deno.env.get("COSENSE_API_BASE");
+
 /**
- * Cosense APIからページと画像を取得するスタブ実装。
- * 実際のAPI連携は未実装で、固定データを返す。
+ * Cosense API からページおよび画像を取得するアダプター。
+ * `COSENSE_API_BASE` が未設定の場合はスタブデータを返す。
  */
-export function fetchPages(
+export async function fetchPages(
   project: string,
-  _sid?: string,
+  sid?: string,
 ): Promise<Page[]> {
-  const text = `# ${project}\nサンプルページ`;
-  return Promise.resolve([
-    { path: "README.md", content: text },
-    { path: "docs/spec.md", content: "# 仕様\n" },
-    { path: "images/logo.png", content: "", binary: new Uint8Array() },
-  ]);
+  if (!API_BASE) {
+    const text = `# ${project}\nサンプルページ`;
+    return [
+      { path: "README.md", content: text },
+      { path: "docs/spec.md", content: "# 仕様\n" },
+      { path: "images/logo.png", content: "", binary: new Uint8Array() },
+    ];
+  }
+
+  const headers = new Headers();
+  if (sid) headers.set("Cookie", `sid=${sid}`);
+
+  const res = await fetch(
+    `${API_BASE}/projects/${encodeURIComponent(project)}/export`,
+    { headers },
+  );
+
+  if (!res.ok) {
+    throw new Error(`Cosense API error: ${res.status}`);
+  }
+
+  const data: { pages: { path: string; content: string; binary?: string }[] } =
+    await res.json();
+
+  return data.pages.map((p) => ({
+    path: p.path,
+    content: p.content,
+    binary: p.binary
+      ? Uint8Array.from(atob(p.binary), (c) => c.charCodeAt(0))
+      : undefined,
+  }));
 }

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15,7 +15,7 @@
 
 - [x] `/api/preview` ハンドラー実装
 - [x] `/api/export` ハンドラー実装
-- [ ] `cosense.ts`: Cosense API アダプター
+- [x] `cosense.ts`: Cosense API アダプター
 - [x] `markdown.ts`: Markdown 変換 + リンク書換
 - [x] `zip.ts`: JSZip ストリーム生成
 


### PR DESCRIPTION
## 変更内容
- `cosense.ts` に Cosense API 連携処理を実装し、環境変数 `COSENSE_API_BASE` 未設定時はスタブデータを返すようにしました。
- `docs/TODO.md` の Team B 残項目を完了としてチェックしました。

## 動作確認
- `deno task check` で lint と fmt が正常終了することを確認。


------
https://chatgpt.com/codex/tasks/task_e_685975c6e46c8331b4b394630a96df42