### PR TITLE
fix vercel build path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.vercel

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "cosense-exporter-root",
+  "private": true,
+  "scripts": {
+    "vercel-build": "npm --prefix next-app install && npm --prefix next-app run build"
+  },
+  "dependencies": {
+    "next": "15.3.4"
+  }
+}


### PR DESCRIPTION
## Summary
- Vercel で Next.js が検出できなかったため、ルートに `package.json` を追加して `next-app` をビルドするように変更
- ルートに `.gitignore` を追加して `node_modules` と `.vercel` を無視

## Testing
- `deno task fmt`
- `deno task lint`
- `deno task check`
- `npm install` と `npm run lint`（`next-app`）
- `npm run build`（`next-app`）

------
https://chatgpt.com/codex/tasks/task_e_6859e1df282883318311a16ef44b6781