### PR TITLE
fix vercel build path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.vercel

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "cosense-exporter-root",
+  "private": true,
+  "scripts": {
+    "vercel-build": "npm --prefix next-app install --include=dev && npm --prefix next-app run build"
+  },
+  "dependencies": {
+    "next": "15.3.4"
+  }
+}


### PR DESCRIPTION
## Summary
- Vercel ビルド時に devDependencies をインストールするように `package.json` を修正

## Testing
- `deno task fmt`
- `deno task lint`
- `deno task check`
- `npm install`
- `npm --prefix next-app run lint`
- `npm --prefix next-app run build`


------
https://chatgpt.com/codex/tasks/task_e_6859e1df282883318311a16ef44b6781