### PR TITLE
Scrapbox API fetch implementation

### DIFF
--- a/cosense.ts
+++ b/cosense.ts
@@ -5,17 +5,42 @@ export interface Page {
 }
 
 /**
- * Cosense APIからページと画像を取得するスタブ実装。
- * 実際のAPI連携は未実装で、固定データを返す。
+ * Scrapbox APIから全ページを取得する簡易実装。
+ * 画像は未対応で、ページ本文のみを返す。
  */
-export function fetchPages(
+export async function fetchPages(
   project: string,
-  _sid?: string,
+  sid?: string,
 ): Promise<Page[]> {
-  const text = `# ${project}\nサンプルページ`;
-  return Promise.resolve([
-    { path: "README.md", content: text },
-    { path: "docs/spec.md", content: "# 仕様\n" },
-    { path: "images/logo.png", content: "", binary: new Uint8Array() },
-  ]);
+  const headers = new Headers();
+  if (sid) {
+    const cookie = sid.includes("=") ? sid : `connect.sid=${sid}`;
+    headers.set("Cookie", cookie);
+  }
+
+  const listRes = await fetch(
+    `https://scrapbox.io/api/pages/${project}?limit=1000`,
+    { headers },
+  );
+  if (!listRes.ok) {
+    throw new Error(`Failed to fetch page list: ${listRes.status}`);
+  }
+  const listData = await listRes.json();
+
+  const pages: Page[] = [];
+  for (const { title } of listData.pages as Array<{ title: string }>) {
+    const enc = encodeURIComponent(title);
+    const pageRes = await fetch(
+      `https://scrapbox.io/api/pages/${project}/${enc}`,
+      { headers },
+    );
+    if (!pageRes.ok) continue;
+    const pageData = await pageRes.json();
+    const lines = pageData.lines as Array<{ text: string }>;
+    const content = lines.slice(1).map((l) => l.text).join("\n");
+    const safeTitle = title.replace(/[\\/:*?"<>|]/g, "_");
+    pages.push({ path: `${safeTitle}.md`, content });
+  }
+
+  return pages;
 }


### PR DESCRIPTION
## Summary
- implement real `fetchPages` using Scrapbox API

## Testing
- `deno lint --ignore=docs,next-app && deno fmt --check --ignore=docs,next-app`

------
https://chatgpt.com/codex/tasks/task_e_685d25f95c448331ba78fc59818607b3