### PR TITLE
ビルドエラーの修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cosense-exporter-root",
   "private": true,
   "scripts": {
-    "vercel-build": "npm --prefix next-app install --include=dev && npm --prefix next-app run build && cp -r next-app/.next .next"
+    "vercel-build": "rm -rf .next && npm --prefix next-app install --include=dev && npm --prefix next-app run build && cp -r next-app/.next .next"
   },
   "dependencies": {
     "next": "15.3.4"


### PR DESCRIPTION
## 概要
`vercel-build` スクリプトで `.next` ディレクトリが入れ子になることがあり、`routes-manifest.json` が見つからずビルドに失敗していました。`cp` 前に既存の `.next` を削除することで解決します。

## 変更点
- `package.json` の `vercel-build` スクリプトを更新し、コピー前に `rm -rf .next` を実行

## テスト
- `npm run vercel-build` を実行し、ビルドが成功することを確認

------
https://chatgpt.com/codex/tasks/task_e_685d296993788331b295ce9ef5bd0dd1