### PR TITLE
zip生成の修正

### DIFF
--- a/zip.ts
+++ b/zip.ts
@@ -8,9 +8,9 @@ export async function buildZip(pages: Page[]): Promise<Uint8Array> {
   const zip = new JSZip();
   for (const page of pages) {
     if (page.binary) {
-      zip.addFile(page.path, page.binary);
+      zip.file(page.path, page.binary);
     } else {
-      zip.addFile(page.path, page.content);
+      zip.file(page.path, page.content);
     }
   }
   return await zip.generateAsync({ type: "uint8array" });
@@ -23,9 +23,9 @@ export function streamZip(pages: Page[]): ReadableStream<Uint8Array> {
   const zip = new JSZip();
   for (const page of pages) {
     if (page.binary) {
-      zip.addFile(page.path, page.binary);
+      zip.file(page.path, page.binary);
     } else {
-      zip.addFile(page.path, page.content);
+      zip.file(page.path, page.content);
     }
   }
   return new ReadableStream<Uint8Array>({


### PR DESCRIPTION
## 概要
JSZip のメソッド使用ミスにより生成した ZIP が壊れていた問題を修正しました。

## 変更点
- `zip.ts` にて `zip.addFile` を `zip.file` へ修正
- `deno task check` を実行し lint とフォーマット確認済み

## 動作確認
`deno task check` が成功することを確認しました。

------
https://chatgpt.com/codex/tasks/task_e_685d30f72b9c83318398778bb696fef5