### PR TITLE
zip出力の修正

### DIFF
--- a/api/export.ts
+++ b/api/export.ts
@@ -1,5 +1,5 @@
 import { fetchPages } from "../cosense.ts";
-import { streamZip } from "../zip.ts";
+import { buildZip } from "../zip.ts";
 
 export const config = { runtime: "vercel-deno@3.1.1" };
 
@@ -9,8 +9,8 @@ export default async function handler(req: Request): Promise<Response> {
   }
   const { project, sid } = await req.json();
   const pages = await fetchPages(project, sid);
-  const stream = streamZip(pages);
-  return new Response(stream, {
+  const data = await buildZip(pages);
+  return new Response(data, {
     headers: {
       "Content-Type": "application/zip",
       "Content-Disposition": "attachment; filename=export.zip",

--- a/index.html
+++ b/index.html
@@ -66,8 +66,19 @@
         return lines.join("\n");
       }
 
+      function normalizeProject(input) {
+        try {
+          const url = new URL(input);
+          const [project] = url.pathname.split("/").filter(Boolean);
+          return project || input;
+        } catch {
+          return input;
+        }
+      }
+
       async function doPreview() {
-        const project = document.getElementById("project").value;
+        const raw = document.getElementById("project").value;
+        const project = normalizeProject(raw);
         const sid = document.getElementById("sid").value || undefined;
         const res = await fetch("/api/preview", {
           method: "POST",
@@ -82,7 +93,8 @@
       }
 
       async function doExport() {
-        const project = document.getElementById("project").value;
+        const raw = document.getElementById("project").value;
+        const project = normalizeProject(raw);
         const sid = document.getElementById("sid").value || undefined;
         const res = await fetch("/api/export", {
           method: "POST",

--- a/next-app/src/app/page.tsx
+++ b/next-app/src/app/page.tsx
@@ -4,6 +4,7 @@ import { motion } from "framer-motion";
 import ExportForm from "../components/ExportForm";
 import PreviewModal from "../components/PreviewModal";
 import type { FileNode } from "../lib/types";
+import { normalizeProject } from "../lib/utils";
 
 export default function Home() {
   const [preview, setPreview] = useState<
@@ -14,20 +15,22 @@ export default function Home() {
   >(null);
 
   async function handlePreview(project: string, sid?: string) {
+    const normalized = normalizeProject(project);
     const res = await fetch("/api/preview", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ project, sid }),
+      body: JSON.stringify({ project: normalized, sid }),
     });
     const data = await res.json();
     setPreview({ fileTree: data.fileTree, sampleHtml: data.sampleHtml });
   }
 
   async function handleExport(project: string, sid?: string) {
+    const normalized = normalizeProject(project);
     const res = await fetch("/api/export", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ project, sid }),
+      body: JSON.stringify({ project: normalized, sid }),
     });
     const blob = await res.blob();
     const url = URL.createObjectURL(blob);

--- a/next-app/src/lib/utils.ts
+++ b/next-app/src/lib/utils.ts
@@ -1,0 +1,9 @@
+export function normalizeProject(input: string): string {
+  try {
+    const url = new URL(input);
+    const [project] = url.pathname.split("/").filter(Boolean);
+    return project || input;
+  } catch {
+    return input;
+  }
+}

--- a/server.ts
+++ b/server.ts
@@ -2,7 +2,7 @@ import { serve } from "https://deno.land/std@0.203.0/http/server.ts";
 import { contentType } from "https://deno.land/std@0.203.0/media_types/mod.ts";
 import { fetchPages } from "./cosense.ts";
 import { buildFileTree, FileNode } from "./file_tree.ts";
-import { streamZip } from "./zip.ts";
+import { buildZip } from "./zip.ts";
 
 const handler = async (req: Request): Promise<Response> => {
   const { pathname } = new URL(req.url);
@@ -43,8 +43,8 @@ const handler = async (req: Request): Promise<Response> => {
   if (req.method === "POST" && pathname === "/api/export") {
     const { project, sid } = await req.json();
     const pages = await fetchPages(project, sid);
-    const stream = streamZip(pages);
-    return new Response(stream, {
+    const data = await buildZip(pages);
+    return new Response(data, {
       headers: {
         "Content-Type": "application/zip",
         "Content-Disposition": "attachment; filename=export.zip",

--- a/zip.ts
+++ b/zip.ts
@@ -8,9 +8,9 @@ export async function buildZip(pages: Page[]): Promise<Uint8Array> {
   const zip = new JSZip();
   for (const page of pages) {
     if (page.binary) {
-      zip.addFile(page.path, page.binary);
+      zip.file(page.path, page.binary);
     } else {
-      zip.addFile(page.path, page.content);
+      zip.file(page.path, page.content);
     }
   }
   return await zip.generateAsync({ type: "uint8array" });
@@ -23,9 +23,9 @@ export function streamZip(pages: Page[]): ReadableStream<Uint8Array> {
   const zip = new JSZip();
   for (const page of pages) {
     if (page.binary) {
-      zip.addFile(page.path, page.binary);
+      zip.file(page.path, page.binary);
     } else {
-      zip.addFile(page.path, page.content);
+      zip.file(page.path, page.content);
     }
   }
   return new ReadableStream<Uint8Array>({


### PR DESCRIPTION
## 概要
`streamZip` で返していた `ReadableStream` が環境によって正しく扱われず、ダウンロードした ZIP が壊れてしまう問題を修正しました。代わりに `buildZip` を使って `Uint8Array` を生成してからレスポンスを返します。

## 変更点
- `api/export.ts` と `server.ts` で `streamZip` の利用を廃止し `buildZip` に変更
- `deno task check` を実行し、lint とフォーマット確認済み
- 入力が URL の場合でも正しくプロジェクト ID を抽出するようフロントエンドを修正

## 動作確認
`deno task check` が成功することを確認しました。

------
https://chatgpt.com/codex/tasks/task_e_685d30f72b9c83318398778bb696fef5