### PR TITLE
プレビューAPIをNext.js開発環境向けに追加

### DIFF
--- a/next-app/src/app/api/export/route.ts
+++ b/next-app/src/app/api/export/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchPages } from '../../../../../cosense';
+import JSZip from 'jszip';
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const { project, sid } = await req.json();
+  const pages = await fetchPages(project, sid);
+  const zip = new JSZip();
+  for (const page of pages) {
+    if (page.binary) {
+      zip.file(page.path, page.binary);
+    } else {
+      zip.file(page.path, page.content);
+    }
+  }
+  const data = await zip.generateAsync({ type: 'uint8array' });
+  return new NextResponse(data, {
+    headers: {
+      'Content-Type': 'application/zip',
+      'Content-Disposition': 'attachment; filename=export.zip',
+    },
+  });
+}

--- a/next-app/src/app/api/preview/route.ts
+++ b/next-app/src/app/api/preview/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchPages } from '../../../../../cosense';
+import { buildFileTree, FileNode } from '../../../../../file_tree';
+import { toHtml } from '../../../../../markdown';
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const { project, sid } = await req.json();
+  const pages = await fetchPages(project, sid);
+  const fileTree: FileNode[] = buildFileTree(pages);
+  const readme = pages.find((p) => p.path === 'README.md');
+  const sampleHtml = readme ? toHtml(readme.content) : '';
+  return NextResponse.json({ fileTree, sampleHtml });
+}


### PR DESCRIPTION
## 変更点
- `src/app/api` 配下に `preview` と `export` のルートを追加
- 開発用サーバーでも `/api/*` が利用できるようにしました

## テスト
- `npx tsc --noEmit -p next-app/tsconfig.json`
- `npm run lint --prefix next-app`
- `npm run test:e2e --prefix next-app` (Playwright のブラウザ取得に失敗しテストは未実行)


------
https://chatgpt.com/codex/tasks/task_e_6867b6dcbe1883319d9c75692ad1360e