### PR TITLE
Add Playwright E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,5 @@ jobs:
       - run: npm --prefix next-app ci
       - run: npm --prefix next-app run lint
       - run: npm --prefix next-app run build
-      - run: npx playwright install
-      - run: npx playwright test
+      - run: npx --prefix next-app playwright install
+      - run: npx --prefix next-app playwright test --config next-app/playwright.config.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    defaults:
-      working-directory: ./next-app
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "npm"
-          cache-dependency-path: ./next-app/package-lock.json
+          cache-dependency-path: |-
+            package-lock.json
+            next-app/package-lock.json
       - run: npm ci
-      - run: npm run lint
-      - run: npm run build
+      - run: npm --prefix next-app ci
+      - run: npm --prefix next-app run lint
+      - run: npm --prefix next-app run build
+      - run: npx playwright install
+      - run: npx playwright test

--- a/README.md
+++ b/README.md
@@ -44,3 +44,16 @@ Vercel プロジェクトに紐づいていれば、次のコマンドでデプ�
 vercel deploy --prod
 ```
 
+## E2E テスト
+
+Playwright を利用したエンドツーエンドテストを `tests/` ディレクトリに配置しています。
+ブラウザをインストールした上で次のコマンドを実行してください。
+
+```bash
+npm --prefix next-app install
+npx playwright install
+npx playwright test
+```
+
+テスト実行時には `npm run dev` が自動で起動し、`http://localhost:3000` でアプリが提供されます。
+

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Playwright を利用したエンドツーエンドテストを `tests/` ディ�
 
 ```bash
 npm --prefix next-app install
-npx playwright install
-npx playwright test
+npx --prefix next-app playwright install
+npx --prefix next-app playwright test --config next-app/playwright.config.ts
 ```
 
 テスト実行時には `npm run dev` が自動で起動し、`http://localhost:3000` でアプリが提供されます。

--- a/next-app/package-lock.json
+++ b/next-app/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.41.2",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -58,6 +59,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.4.tgz",
       "integrity": "sha512-A9CnAbC6ARNMKcIcrQwq6HeHCjpcBZ5wSx4U01WXCqEKlrzB9F9315WDNHkrs2xbx7YjjSxbUYxuN6EQzpcY2g==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -79,6 +81,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.3.tgz",
       "integrity": "sha512-8K5IFFsQqF9wQNJptGbS6FNKgUTsSRYnTqNCG1vPP8jFdjSv18n2mQfJpkt2Oibo9iBEzcDnDxNwKTzC7svlJw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -761,6 +764,7 @@
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
       "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -959,6 +963,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.1.tgz",
+      "integrity": "sha512-FS8hQ12acieG2dYSksmLOF7BNxnVf2afRJdCuM1eMSxj6QTSE6G4InGF7oApGgDb65MX7AwMVlIkpru0yZA4Xw==",
+      "devOptional": true,
+      "dependencies": {
+        "playwright": "1.54.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -1206,6 +1225,60 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.4.3",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.4.3",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.11",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.9.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.0",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.11.tgz",
@@ -1255,6 +1328,7 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
       "integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3352,6 +3426,20 @@
         }
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5044,6 +5132,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.1.tgz",
+      "integrity": "sha512-peWpSwIBmSLi6aW2auvrUtf2DqY16YYcCMO8rTVx486jKmDTJg7UAhyrraP98GB8BoPURZP8+nxO7TSd4cPr5g==",
+      "devOptional": true,
+      "dependencies": {
+        "playwright-core": "1.54.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.1.tgz",
+      "integrity": "sha512-Nbjs2zjj0htNhzgiy5wu+3w09YetDx5pkrpI/kZotDlDUaYk0HVA5xrBVPdow4SAUIlhgKcJeJg4GRKW6xHusA==",
+      "devOptional": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -24,7 +24,8 @@
     "eslint-config-next": "15.3.4",
     "jszip": "^3.10.1",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "@playwright/test": "^1.41.2"
   },
   "engines": {
     "node": "20.x"

--- a/next-app/playwright.config.ts
+++ b/next-app/playwright.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  use: { baseURL: 'http://localhost:3000' },
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/next-app/tests/export.spec.ts
+++ b/next-app/tests/export.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+import JSZip from 'jszip';
+
+const PROJECT = 'cosense-exporter-test';
+
+async function readZip(buffer: Buffer) {
+  const zip = await JSZip.loadAsync(buffer);
+  const files = Object.keys(zip.files);
+  return files;
+}
+
+test('preview and export', async ({ page, request }) => {
+  await page.goto('/');
+  await page.fill('input:nth-of-type(1)', PROJECT);
+  await page.click('button:has-text("プレビュー")');
+  const modal = page.locator('pre');
+  await expect(modal).toContainText('test1.md');
+  await expect(modal).toContainText('test2.md');
+  await page.click('button:has-text("エクスポート")');
+  const resp = await page.waitForResponse(res => res.url().includes('/api/export') && res.status() === 200);
+  expect(resp.headers()['content-type']).toBe('application/zip');
+  const buf = Buffer.from(await resp.body());
+  const files = await readZip(buf);
+  expect(files).toContain('test1.md');
+  expect(files).toContain('test2.md');
+});
+


### PR DESCRIPTION
## Summary
- add @playwright/test and lockfile update
- configure Playwright to launch the dev server
- add basic export flow test
- run Playwright in CI
- document how to run E2E tests

## Testing
- `npx playwright install chromium` *(fails: Cannot install without network)@
- `npx playwright test` *(fails: Cannot find module '@playwright/test' because dependencies not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6873a3b186508331b692b5bfed5f3020